### PR TITLE
use UIGraphicsBeginImageContextWithOptions(size, NO, 0.0) to take advanta

### DIFF
--- a/OpenFlow/AFUIImageReflection.m
+++ b/OpenFlow/AFUIImageReflection.m
@@ -74,7 +74,7 @@
 	
 	CGSize size = CGSizeMake(self.size.width, self.size.height + reflectionHeight);
 	
-	UIGraphicsBeginImageContext(size);
+	UIGraphicsBeginImageContextWithOptions(size, NO, 0.0);
 	
 	[self drawAtPoint:CGPointZero];
 	CGContextRef context = UIGraphicsGetCurrentContext();


### PR DESCRIPTION
use UIGraphicsBeginImageContextWithOptions(size, NO, 0.0) to take advantage of retina display scale factor
