### PR TITLE
Update OpenFlow/AFOpenFlowView.m

### DIFF
--- a/OpenFlow/AFOpenFlowView.m
+++ b/OpenFlow/AFOpenFlowView.m
@@ -53,7 +53,7 @@ const static CGFloat kReflectionFraction = 0.85;
 	offscreenCovers = [[NSMutableSet alloc] init];
 	onscreenCovers = [[NSMutableDictionary alloc] init];
 	
-	scrollView = [[UIScrollView alloc] initWithFrame:self.frame];
+	scrollView = [[UIScrollView alloc] initWithFrame:self.bounds];
 	scrollView.userInteractionEnabled = NO;
 	scrollView.multipleTouchEnabled = NO;
 	scrollView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;


### PR DESCRIPTION
The scrollview should actually be positioned at (0,0) which is why it should be inited with the View's bounds instead of frame.
